### PR TITLE
Fix for crash in empty mass tagger

### DIFF
--- a/source/puddlestuff/audioinfo/util.py
+++ b/source/puddlestuff/audioinfo/util.py
@@ -620,7 +620,7 @@ class CaselessDict(dict):
 
     def __deepcopy__(self, memo):
         cls = CaselessDict()
-        for key, value in dict.iteritems(self):
+        for key, value in self.items():
             cls[key] = deepcopy(value)
         return cls
 


### PR DESCRIPTION
Fixes exception caused by clicking on search button in mass tagger with no tagging options selected.

```
Traceback (most recent call last):
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/dialogs.py", line 585, in lookup
    self._start()
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/dialogs.py", line 620, in _start
    tag_groups = split_files(self._status['selectedfiles'],
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/__init__.py", line 531, in split_files
    tag_groups.append(list(map(copy_audio, album_files)))
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/__init__.py", line 521, in copy_audio
    audio_copy = deepcopy(f)
  File "/usr/lib64/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/audioinfo/vorbis.py", line 117, in __deepcopy__
    cls.set_fundamentals(deepcopy(self.__tags),
  File "/usr/lib64/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/audioinfo/util.py", line 623, in __deepcopy__
    for key, value in dict.iteritems(self):
AttributeError: type object 'dict' has no attribute 'iteritems'
launch.bash: line 3:  4516 Aborted                 (core dumped) PYTHONPATH=source/ ./source/puddletag

```